### PR TITLE
Global flag to enable flushing write buffer after

### DIFF
--- a/format/rtmp/rtmp.go
+++ b/format/rtmp/rtmp.go
@@ -20,6 +20,7 @@ import (
 	"time"
 )
 
+// Debug enables debug output
 var Debug bool
 
 func ParseURL(uri string) (u *url.URL, err error) {
@@ -1019,7 +1020,10 @@ func (self *Conn) writeAVTag(tag flvio.Tag, ts int32) (err error) {
 	if _, err = self.bufw.Write(b[:n]); err != nil {
 		return
 	}
-	_, err = self.bufw.Write(data)
+	if _, err = self.bufw.Write(data); err != nil {
+		return
+	}
+	err = self.bufw.Flush()
 	return
 }
 


### PR DESCRIPTION
Global flag to enable flushing write buffer after
each `writeAVTag` call.
Fixes issue with small segments not arriving at time when
re-streaming RTMP stream.
Fixes livepeer/lpms#128
Fixes livepeer/go-livepeer#885
